### PR TITLE
Make `docker-compose up` work on M1 MacBooks

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -75,7 +75,10 @@ Rails.application.configure do
   # config.action_mailer.default_url_options = { host: 'localhost', port: 3000 }
   # config.action_mailer.delivery_method = :letter_opener
   # config.action_mailer.perform_deliveries = true
-  config.file_watcher = ActiveSupport::EventedFileUpdateChecker
+
+  # Docker uses qemu on M1 Macs, which doesn't support inotify.
+  # `ActiveSupport::EventedFileUpdateChecker` requires inotify.
+  # config.file_watcher = ActiveSupport::EventedFileUpdateChecker
 
   # Make javascript_pack_tag load assets from webpack-dev-server.
   # config.x.webpacker[:dev_server_host] = 'http://localhost:8080'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,8 @@ services:
   database:
     # Use the postgres 11.5 base image for this container.
     image: postgres:11.5
+    
+    platform: "linux/amd64"
 
     volumes:
       # We need to tell Docker where on the PostgreSQL
@@ -38,6 +40,8 @@ services:
   web:
     # The root directory from which we're building.
     build: .
+    
+    platform: "linux/amd64"
 
     # This makes it so any code changes inside the project
     # directory get synced with Docker. Without this line,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -74,3 +74,7 @@ services:
 # Declare the volumes that our application uses.
 volumes:
   db_data:
+
+networks:
+  default:
+    driver: bridge


### PR DESCRIPTION
Fixes https://github.com/Australian-Genomics/CTRL/issues/1. The three changes required to make CTRL work in Docker on an M1 MacBook are well-separated by commit. The changes are:

* 7a549485aa9dfa84baf30a8e933b4539668e8b8b - Add `platform: "linux/amd64"` to `docker-compose.yml`
* 32342787bc95bdaee45163c825f1ef0bbd244ea1 - Don't use `inotify`. Docker on M1 doesn't support it. I'm not sure what the implications of this change are. I assume `inotify` just endows Ruby on Rails with the ability to dynamically load changes to the app's source without restarting. This change only affects the development environment, so it seems safe.
* 154f83cc50dc60c74d77d3f84014c9e357c6be2e - Add network bridge to `docker-compose.yml` so that the `web` service can communicate with the `database` service.

Some configuration is also necessary to make `docker-compose up -d --build` work as described in issue https://github.com/Australian-Genomics/CTRL/issues/1. This configuration should be documented as part of the resolution to issue https://github.com/Australian-Genomics/CTRL/issues/3.