### PR TITLE
Add tour videos to seed data

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -13,4 +13,5 @@ jobs:
       - run: docker-compose run web yarn install
       - run: docker-compose run web bundle exec rails db:create
       - run: docker-compose run web bundle exec rails db:migrate
+      - run: docker-compose run web bundle exec rails db:seed
       - run: docker-compose run web bash -c 'RAILS_ENV=test bundle exec rspec'

--- a/db/seed_data/consent_steps.yml
+++ b/db/seed_data/consent_steps.yml
@@ -7,6 +7,8 @@
   popover:  |
     Watch the video introduction to why we are asking you to provide your
     consent to our program online.
+  tour_videos: |
+    https://www.youtube.com/embed/Du8kYb_9AKY
 
 - title: Consent for the genomic test
   order: 2


### PR DESCRIPTION
Resolves #15. The issue was occurring because tour videos weren't being added to the 1st consent step. The change to `db/seed_data/consent_steps.yml` fixes that. I've also added `rails db:seed` to our CI pipeline so that it doesn't start failing unnoticed in the future.