### PR TITLE
Fix footer position

### DIFF
--- a/app/javascript/packs/consent_form.js
+++ b/app/javascript/packs/consent_form.js
@@ -15,7 +15,9 @@ Vue.use(VModal)
 const app = new Vue({
   render: h => h(App)
 }).$mount()
-document.body.appendChild(app.$el)
+document.body.onload = function() {
+  document.getElementById('consent-form-anchor').replaceWith(app.$el);
+}
 
 // The above code uses Vue without the compiler, which means you cannot
 // use Vue to target elements in your existing html templates. You would

--- a/app/views/consent/edit.html.erb
+++ b/app/views/consent/edit.html.erb
@@ -1,1 +1,2 @@
 <%= javascript_pack_tag 'consent_form' %>
+<div id="consent-form-anchor"></div>


### PR DESCRIPTION
Resolves #14, which was reopened after we discovered that the "Powered by CTRL" footer sometimes appeared at the top of the page. The issue was caused by an async JavaScript bug. On the `/consent-form` page, the contents are added by a call to `document.body.appendChild`. Sometimes this code would be executed before or after `document.body.onload` occurred, leading the appended element to sometimes be before or after [this](https://github.com/Australian-Genomics/CTRL/blob/a6194f7a571d8925636aa740f4757fce285ed65e/app/views/layouts/application.html.erb#L16-L18) footer.