### PR TITLE
Allow hyperlinks within questions

### DIFF
--- a/app/javascript/components/StepInitial.vue
+++ b/app/javascript/components/StepInitial.vue
@@ -1,9 +1,7 @@
 <template>
   <div>
     <div class="d-flex mb-30">
-      <p class="text-center mx-auto mb-0">
-        {{ surveyStep.description }}
-      </p>
+      <p class="text-center mx-auto mb-0" v-html="surveyStep.description"></p>
     </div>
 
     <div class="steps__iframe">


### PR DESCRIPTION
Resolves #19. Note that hyperlinks were already _mostly_ working before this PR. From the admin portal (at `/admin`), the user can include `<a href="...">...</a>` tags in questions and descriptions, and they'll be interpreted as HTML by the browser. The only place where hyperlinks weren't working was the first step in the survey, because that step didn't use [Vue.js's `v-html` directive](https://vuejs.org/api/built-in-directives.html#v-html), and the other pages a rendered server-side, without [`html_safe`](https://apidock.com/rails/String/html_safe).

Note that the use case in #19's description isn't satisfied by this PR. A separate issue (https://github.com/Australian-Genomics/CTRL/issues/34) was raised for that and I expect another PR by late today or early tomorrow.