### PR TITLE
Fix Vue.js mounting race condition

### DIFF
--- a/app/javascript/packs/consent_form.js
+++ b/app/javascript/packs/consent_form.js
@@ -13,11 +13,9 @@ import App from '../consent-form.vue'
 Vue.use(VModal)
 
 const app = new Vue({
+  el: "#consent-form-anchor",
   render: h => h(App)
-}).$mount()
-document.body.onload = function() {
-  document.getElementById('consent-form-anchor').replaceWith(app.$el);
-}
+})
 
 // The above code uses Vue without the compiler, which means you cannot
 // use Vue to target elements in your existing html templates. You would

--- a/app/views/consent/edit.html.erb
+++ b/app/views/consent/edit.html.erb
@@ -1,2 +1,2 @@
-<%= javascript_pack_tag 'consent_form' %>
 <div id="consent-form-anchor"></div>
+<%= javascript_pack_tag 'consent_form' %>


### PR DESCRIPTION
I attempted this in https://github.com/Australian-Genomics/CTRL/pull/27 but introduced a different race condition. I think this line was sometimes getting executed before or after the body had loaded:

```javascript
document.body.onload = function() {
  document.getElementById('consent-form-anchor').replaceWith(app.$el);
}
```

If the body had already loaded before `document.body.onload` was set, the function referred to by `document.body.onload` wouldn't be executed. The solution is to let Vue.js do the DOM node replacement by passing `el: "#consent-form-anchor"` and to declare the `#consent-form-anchor` element before the Vue.js script which replaces it.