### PR TITLE
Make responses save upon clicking "Back" button

### DIFF
--- a/app/assets/stylesheets/layout/_base.sass
+++ b/app/assets/stylesheets/layout/_base.sass
@@ -50,3 +50,19 @@ video
 .generic-person-image
   height: 150px
   margin: 30px auto 30px
+
+#modal-loading
+    position: fixed
+    left: 0
+    top: 0
+    width: 100vw
+    height: 100vh
+    background: rgba(0, 0, 0, 0.2)
+    display: flex
+    justify-content: center
+    align-items: center
+    z-index: 999
+
+#modal-loading img
+  height: 200px
+  width: 200px

--- a/features/consent/step_five.feature
+++ b/features/consent/step_five.feature
@@ -48,6 +48,29 @@ Feature: Consent Page
     When I click on Back
     Then I should see the step four of the consent
 
+  Scenario: Going back to step four saves step five
+    Given I do not exist as a user
+    And A study code exists
+    When I click on Register
+    And I fill in the user details
+    Then I should see the step one of consent
+    When I click on Next
+    Then I should see the step two of the consent
+    When I click all the checkboxes
+    And I click on Next
+    Then I should be on the step three page of consent
+    When I click all the checkboxes
+    When I click the Next button
+    Then I should see the step four of the consent
+    When I click the Next button
+    Then I should see the step five of the consent
+    When I click the first radio button
+    And I click on Back
+    Then I should see the step four of the consent
+    When I click the Next button
+    Then I should see the step five of the consent
+    And the first radio button should be selected
+
   Scenario: User can save and go to the dashboard page
     Given I do not exist as a user
     And A study code exists

--- a/features/step_definitions/confirm_answers_steps.rb
+++ b/features/step_definitions/confirm_answers_steps.rb
@@ -8,6 +8,7 @@ Then('I should be on the confirm answers page') do
 end
 
 Then('I should see the step three of the consent') do
+  expect(page).to have_content('Step 3 of 5')
   expect(page).to have_button('Next')
   expect(page).to have_button('Save and Exit')
 end

--- a/features/step_definitions/step_five_steps.rb
+++ b/features/step_definitions/step_five_steps.rb
@@ -1,0 +1,11 @@
+When(/I click the first radio button/) do
+  first('.controls__radio').click
+end
+
+Then(/the first radio button should be selected/) do
+  first_radio_button_matching_text = first(
+    '.controls__radio input',
+    visible: false
+  )
+  expect(first_radio_button_matching_text).to be_checked
+end

--- a/public/spinner.svg
+++ b/public/spinner.svg
@@ -1,0 +1,51 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 100 100" preserveAspectRatio="xMidYMid">
+  <g transform="rotate(0 50 50)">
+    <rect x="47" y="24" rx="3" ry="6" width="6" height="12" fill="#ffffff">
+      <animate attributeName="opacity" values="1;0" keyTimes="0;1" dur="1s" begin="-0.9166666666666666s" repeatCount="indefinite"></animate>
+    </rect>
+  </g><g transform="rotate(30 50 50)">
+    <rect x="47" y="24" rx="3" ry="6" width="6" height="12" fill="#ffffff">
+      <animate attributeName="opacity" values="1;0" keyTimes="0;1" dur="1s" begin="-0.8333333333333334s" repeatCount="indefinite"></animate>
+    </rect>
+  </g><g transform="rotate(60 50 50)">
+    <rect x="47" y="24" rx="3" ry="6" width="6" height="12" fill="#ffffff">
+      <animate attributeName="opacity" values="1;0" keyTimes="0;1" dur="1s" begin="-0.75s" repeatCount="indefinite"></animate>
+    </rect>
+  </g><g transform="rotate(90 50 50)">
+    <rect x="47" y="24" rx="3" ry="6" width="6" height="12" fill="#ffffff">
+      <animate attributeName="opacity" values="1;0" keyTimes="0;1" dur="1s" begin="-0.6666666666666666s" repeatCount="indefinite"></animate>
+    </rect>
+  </g><g transform="rotate(120 50 50)">
+    <rect x="47" y="24" rx="3" ry="6" width="6" height="12" fill="#ffffff">
+      <animate attributeName="opacity" values="1;0" keyTimes="0;1" dur="1s" begin="-0.5833333333333334s" repeatCount="indefinite"></animate>
+    </rect>
+  </g><g transform="rotate(150 50 50)">
+    <rect x="47" y="24" rx="3" ry="6" width="6" height="12" fill="#ffffff">
+      <animate attributeName="opacity" values="1;0" keyTimes="0;1" dur="1s" begin="-0.5s" repeatCount="indefinite"></animate>
+    </rect>
+  </g><g transform="rotate(180 50 50)">
+    <rect x="47" y="24" rx="3" ry="6" width="6" height="12" fill="#ffffff">
+      <animate attributeName="opacity" values="1;0" keyTimes="0;1" dur="1s" begin="-0.4166666666666667s" repeatCount="indefinite"></animate>
+    </rect>
+  </g><g transform="rotate(210 50 50)">
+    <rect x="47" y="24" rx="3" ry="6" width="6" height="12" fill="#ffffff">
+      <animate attributeName="opacity" values="1;0" keyTimes="0;1" dur="1s" begin="-0.3333333333333333s" repeatCount="indefinite"></animate>
+    </rect>
+  </g><g transform="rotate(240 50 50)">
+    <rect x="47" y="24" rx="3" ry="6" width="6" height="12" fill="#ffffff">
+      <animate attributeName="opacity" values="1;0" keyTimes="0;1" dur="1s" begin="-0.25s" repeatCount="indefinite"></animate>
+    </rect>
+  </g><g transform="rotate(270 50 50)">
+    <rect x="47" y="24" rx="3" ry="6" width="6" height="12" fill="#ffffff">
+      <animate attributeName="opacity" values="1;0" keyTimes="0;1" dur="1s" begin="-0.16666666666666666s" repeatCount="indefinite"></animate>
+    </rect>
+  </g><g transform="rotate(300 50 50)">
+    <rect x="47" y="24" rx="3" ry="6" width="6" height="12" fill="#ffffff">
+      <animate attributeName="opacity" values="1;0" keyTimes="0;1" dur="1s" begin="-0.08333333333333333s" repeatCount="indefinite"></animate>
+    </rect>
+  </g><g transform="rotate(330 50 50)">
+    <rect x="47" y="24" rx="3" ry="6" width="6" height="12" fill="#ffffff">
+      <animate attributeName="opacity" values="1;0" keyTimes="0;1" dur="1s" begin="0s" repeatCount="indefinite"></animate>
+    </rect>
+  </g>
+</svg>


### PR DESCRIPTION
Resolves #46.

In addition to doing as it says in the title, this PR changes the behaviour of the consent form somewhat to fix a UX bug I noticed while writing a new Cucumber scenario. Steps to reproduce the bug are as follows:

1. On step _n_ in the consent form, enter responses.
2. Click "Next" to navigate to step _n+1_. (Aside from the obvious effect of taking you to the next step, clicking "Next" will cause the responses to start being saved. The user can still navigate freely from step to step before the responses have finished saving.)
3. Before the responses have finished saving, click "Back" to return to step _n_. Because the form had not finished saving, it will load and display stale responses, or the default responses if none had previously ever finished saving.

To fix this issue, I prevented the user from navigating while responses are being saved. I did this by adding a transparent overlay with a spinner in the centre:

![Screenshot_20220829_122012](https://user-images.githubusercontent.com/11529449/187110316-6ba2f0e2-b0ea-4c6b-988e-5fe7413b3d00.png)

![Peek 2022-08-29 12-19](https://user-images.githubusercontent.com/11529449/187110309-914da6dc-bfa2-434c-83ab-d35a5762d3b7.gif)
