### PR TITLE
Make Glossary columns not null

### DIFF
--- a/db/migrate/20220815202346_create_glossary_entries.rb
+++ b/db/migrate/20220815202346_create_glossary_entries.rb
@@ -1,8 +1,8 @@
 class CreateGlossaryEntries < ActiveRecord::Migration[5.2]
   def change
     create_table :glossary_entries do |t|
-      t.string :term
-      t.text :definition
+      t.string :term, null: false
+      t.text :definition, null: false
 
       t.timestamps
     end


### PR DESCRIPTION
Without this, rails keeps modifying `db/schema.rb` not to have `null: false` here: https://github.com/Australian-Genomics/CTRL/blob/344f8cd641cb03a0ac0c18ed46579abfd8c83776/db/schema.rb#L83-L84