### PR TITLE
Send registration page information to REDCap

### DIFF
--- a/app/admin/question_answers.rb
+++ b/app/admin/question_answers.rb
@@ -44,16 +44,16 @@ ActiveAdmin.register QuestionAnswer do
     column(:answer_redcap_field) do |question_answer|
       redcap_response = UploadRedcapDetails.question_answer_to_redcap_response(
         question_answer, false
-      ) || {}
+      ) || [{}]
 
-      redcap_response.except('record_id').keys.first
+      redcap_response.first.except('record_id').keys.first
     end
     column(:answer_redcap_code) do |question_answer|
       redcap_response = UploadRedcapDetails.question_answer_to_redcap_response(
         question_answer, false
-      ) || {}
+      ) || [{}]
 
-      redcap_response.except('record_id').values.first
+      redcap_response.first.except('record_id').values.first
     end
     column :created_at
     column :updated_at

--- a/app/admin/user_column_to_redcap_field_mapping.rb
+++ b/app/admin/user_column_to_redcap_field_mapping.rb
@@ -1,0 +1,37 @@
+ActiveAdmin.register UserColumnToRedcapFieldMapping do
+  permit_params :user_column, :redcap_field, :redcap_event_name
+
+  config.sort_order = 'user_column_asc'
+
+  index do
+    selectable_column
+    id_column
+    column('User Column') do |user_column_to_redcap_field_mapping|
+      user_column_to_redcap_field_mapping.user_column.humanize.upcase
+    end
+    column :redcap_field
+    column :redcap_event_name
+    actions
+  end
+
+  show do
+    attributes_table do
+      row('User Column') do |user_column_to_redcap_field_mapping|
+        user_column_to_redcap_field_mapping.user_column.humanize.upcase
+      end
+      row :redcap_field
+      row :redcap_event_name
+    end
+  end
+
+  form do |f|
+    f.inputs do
+      f.input :user_column, :as => :select, :collection => (User.column_names.map do |column_name|
+          [column_name.humanize.upcase, column_name]
+        end)
+      f.input :redcap_field
+      f.input :redcap_event_name
+    end
+    f.actions
+  end
+end

--- a/app/admin/users.rb
+++ b/app/admin/users.rb
@@ -25,10 +25,15 @@ ActiveAdmin.register User do
       end
 
       column(redcap_field, humanize_name: false) do |user|
-        QuestionAnswer.find_by(
+        question_answer = QuestionAnswer.find_by(
           user_id: user.id,
           consent_question_id: consent_question_id,
-        ).answer
+        )
+        if question_answer.nil?
+          ''
+        else
+          UploadRedcapDetails.answer_string_to_code(question_answer.answer)
+        end
       end
     end
   end

--- a/app/lib/upload_redcap_details.rb
+++ b/app/lib/upload_redcap_details.rb
@@ -35,7 +35,7 @@ class UploadRedcapDetails
       content: 'record',
       format: 'json',
       type: 'flat',
-      data: data
+      data: data.to_json
     }
   end
 
@@ -47,7 +47,7 @@ class UploadRedcapDetails
     end
   end
 
-  def self.question_answer_to_redcap_response(question_answer, destroy)
+  def self.question_answer_to_redcap_response(question_answer, destroy, *_)
     answer_string = question_answer.answer
 
     consent_question = question_answer.consent_question
@@ -74,6 +74,46 @@ class UploadRedcapDetails
     )
   end
 
+  def self.user_to_redcap_response(user, *_)
+    user_id = user.id
+
+    UserColumnToRedcapFieldMapping.all.map { |user_column_to_redcap_field_mapping|
+      user_column, redcap_field, redcap_event_name = [
+        user_column_to_redcap_field_mapping.user_column,
+        user_column_to_redcap_field_mapping.redcap_field,
+        user_column_to_redcap_field_mapping.redcap_event_name]
+
+      is_dropdown = User.defined_enums.has_key?(user_column)
+
+      user_column_value =
+        is_dropdown ?
+          user.read_attribute_before_type_cast(user_column) :
+          user.send(user_column)
+
+      response_base =
+        redcap_event_name.blank? ?
+          {'record_id' => user_id} :
+          {'record_id' => user_id, 'redcap_event_name' => redcap_event_name}
+
+      if user_column_value.nil?
+        {}
+      elsif is_dropdown
+        # Rails stores menu entries in the database as zero-indexed integers.
+        # REDCap stores menu entries as one-indexed integers. We must
+        # increment Rails' integer to get one which REDCap understands.
+        response_base.merge({redcap_field => user_column_value + 1})
+      elsif user_column_value == true
+        response_base.merge({redcap_field => '1'})
+      elsif user_column_value == false
+        response_base.merge({redcap_field => '0'})
+      else
+        response_base.merge({redcap_field => user_column_value})
+      end
+    }.select { |response_hash|
+      response_hash != {}
+    }
+  end
+
   def self.construct_redcap_response(
     raw_redcap_code,
     raw_redcap_field,
@@ -98,20 +138,22 @@ class UploadRedcapDetails
       redcap_code = coded_answer_or_raw_redcap_code
     end
 
-    data = {
-      'record_id' => user_id,
-      redcap_field => redcap_code,
-    }
+    [
+      {
+        'record_id' => user_id,
+        redcap_field => redcap_code,
+      }
+    ]
   end
 
-  def self.perform(question_answer, destroy=false)
-    Rails.logger.info "Performing upload job for question=#{question_answer.pretty_inspect}"
-    data = question_answer_to_redcap_response(question_answer, destroy)
+  def self.perform(data_getter, record, destroy=false)
+    Rails.logger.info "Using #{data_getter} to perform upload job for #{record.pretty_inspect}"
+    data = self.send(data_getter, record, destroy)
     if data.nil?
-      Rails.logger.info "Payload empty; Not posting for question=#{question_answer.pretty_inspect}"
+      Rails.logger.info "Payload empty; Not posting for #{record.pretty_inspect}"
       return
     end
-    redcap_api_payload = make_redcap_api_payload([data].to_json)
+    redcap_api_payload = make_redcap_api_payload(data)
     call_api(redcap_api_payload)
   end
 end

--- a/app/models/question_answer.rb
+++ b/app/models/question_answer.rb
@@ -9,10 +9,10 @@ class QuestionAnswer < ApplicationRecord
   before_destroy :destroy_redcap_details
 
   def upload_redcap_details
-    UploadRedcapDetails.perform(self)
+    UploadRedcapDetails.perform(:question_answer_to_redcap_response, self)
   end
 
   def destroy_redcap_details
-    UploadRedcapDetails.perform(self, true)
+    UploadRedcapDetails.perform(:question_answer_to_redcap_response, self, true)
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -72,6 +72,8 @@ class User < ApplicationRecord
   enum state: %w[ACT NSW NT QLD SA TAS VIC WA]
   enum preferred_contact_method: %w[Email Phone Mail]
 
+  after_save :upload_redcap_details
+
   def kin_details_and_child_details
     if is_parent == false
       validates_presence_of :kin_first_name, :kin_family_name, :kin_contact_no
@@ -90,5 +92,9 @@ class User < ApplicationRecord
       errors.add(:password, :blank)
       false
     end
+  end
+
+  def upload_redcap_details
+    UploadRedcapDetails.perform(:user_to_redcap_response, self)
   end
 end

--- a/app/models/user_column_to_redcap_field_mapping.rb
+++ b/app/models/user_column_to_redcap_field_mapping.rb
@@ -1,0 +1,4 @@
+class UserColumnToRedcapFieldMapping < ApplicationRecord
+  validates :user_column, uniqueness: true
+  validates :redcap_field, uniqueness: { scope: :redcap_event_name }
+end

--- a/db/data.yml
+++ b/db/data.yml
@@ -12,6 +12,64 @@
     password_confirmation: 'tester123'
     dob: 21-12-2002
     study_id: A1543457
+- UserColumnToRedcapFieldMapping:
+  - user_column: created_at
+    redcap_field: ctrl_reg_date
+    redcap_event_name: proband_informatio_arm_1
+  - user_column: first_name
+    redcap_field: ctrl_pers_name
+    redcap_event_name: proband_informatio_arm_1
+  - user_column: family_name
+    redcap_field: ctrl_pers_surname
+    redcap_event_name: proband_informatio_arm_1
+  - user_column: study_id
+    redcap_field: ctrl_stud_id
+    redcap_event_name: proband_informatio_arm_1
+  - user_column: dob
+    redcap_field: ctrl_dob
+    redcap_event_name: proband_informatio_arm_1
+  - user_column: phone_no
+    redcap_field: ctrl_phone_no
+    redcap_event_name: proband_informatio_arm_1
+  - user_column: email
+    redcap_field: ctrl_email
+    redcap_event_name: proband_informatio_arm_1
+  - user_column: preferred_contact_method
+    redcap_field: ctrl_pref_contact_meth
+    redcap_event_name: proband_informatio_arm_1
+  - user_column: is_parent
+    redcap_field: ctrl_pg_register_for_child_yn
+    redcap_event_name: proband_informatio_arm_1
+  - user_column: child_first_name
+    redcap_field: ctrl_child_name
+    redcap_event_name: proband_informatio_arm_1
+  - user_column: child_family_name
+    redcap_field: ctrl_child_surname
+    redcap_event_name: proband_informatio_arm_1
+  - user_column: address
+    redcap_field: ctrl_address
+    redcap_event_name: proband_informatio_arm_1
+  - user_column: suburb
+    redcap_field: ctrl_suburb
+    redcap_event_name: proband_informatio_arm_1
+  - user_column: state
+    redcap_field: ctrl_state
+    redcap_event_name: proband_informatio_arm_1
+  - user_column: post_code
+    redcap_field: ctrl_postcode
+    redcap_event_name: proband_informatio_arm_1
+  - user_column: kin_first_name
+    redcap_field: ctrl_kin_name
+    redcap_event_name: proband_informatio_arm_1
+  - user_column: kin_family_name
+    redcap_field: ctrl_kin_surname
+    redcap_event_name: proband_informatio_arm_1
+  - user_column: kin_contact_no
+    redcap_field: ctrl_kin_contactno
+    redcap_event_name: proband_informatio_arm_1
+  - user_column: kin_email
+    redcap_field: ctrl_kin_email
+    redcap_event_name: proband_informatio_arm_1
 - SurveyConfig:
   - name: Radio Button Color
     value: "#02b0db"

--- a/db/migrate/20221114040630_create_user_column_to_redcap_field_mappings.rb
+++ b/db/migrate/20221114040630_create_user_column_to_redcap_field_mappings.rb
@@ -1,0 +1,12 @@
+class CreateUserColumnToRedcapFieldMappings < ActiveRecord::Migration[5.2]
+  def change
+    create_table :user_column_to_redcap_field_mappings do |t|
+      t.string :user_column, null: false
+      t.string :redcap_field, null: false
+      t.string :redcap_event_name
+    end
+
+    add_index(:user_column_to_redcap_field_mappings, :user_column, unique: true, name: 'uctrfm_user_column_index')
+    add_index(:user_column_to_redcap_field_mappings,  [:redcap_field, :redcap_event_name], unique: true, name: 'uctrfm_redcap_index')
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_10_11_010843) do
+ActiveRecord::Schema.define(version: 2022_11_14_040630) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -159,6 +159,14 @@ ActiveRecord::Schema.define(version: 2022_10_11_010843) do
     t.datetime "updated_at", null: false
     t.boolean "is_file"
     t.string "hint"
+  end
+
+  create_table "user_column_to_redcap_field_mappings", force: :cascade do |t|
+    t.string "user_column", null: false
+    t.string "redcap_field", null: false
+    t.string "redcap_event_name"
+    t.index ["redcap_field", "redcap_event_name"], name: "uctrfm_redcap_index", unique: true
+    t.index ["user_column"], name: "uctrfm_user_column_index", unique: true
   end
 
   create_table "users", force: :cascade do |t|

--- a/db/seeds_lib.rb
+++ b/db/seeds_lib.rb
@@ -28,16 +28,17 @@ def create_related_record_of_type(
   fields_, related_records_hash_ = fields_and_related_records(
     related_records_hash)
   new_record = case related_record_type
-    when "AdminUser"       then record.admin_users.create!(fields_)
-    when "ConsentGroup"    then record.consent_groups.create!(fields_)
-    when "ConsentQuestion" then record.consent_questions.create!(fields_)
-    when "ConsentStep"     then record.consent_steps.create!(fields_)
-    when "GlossaryEntry"   then record.glossary_entries.create!(fields_)
-    when "ModalFallback"   then record.modal_fallbacks.create!(fields_)
-    when "QuestionOption"  then record.question_options.create!(fields_)
-    when "StudyCode"       then record.study_codes.create!(fields_)
-    when "SurveyConfig"    then record.survey_configs.create!(fields_)
-    when "User"            then record.users.create!(fields_)
+    when "AdminUser"                      then record.admin_users.create!(fields_)
+    when "ConsentGroup"                   then record.consent_groups.create!(fields_)
+    when "ConsentQuestion"                then record.consent_questions.create!(fields_)
+    when "ConsentStep"                    then record.consent_steps.create!(fields_)
+    when "GlossaryEntry"                  then record.glossary_entries.create!(fields_)
+    when "ModalFallback"                  then record.modal_fallbacks.create!(fields_)
+    when "QuestionOption"                 then record.question_options.create!(fields_)
+    when "StudyCode"                      then record.study_codes.create!(fields_)
+    when "SurveyConfig"                   then record.survey_configs.create!(fields_)
+    when "User"                           then record.users.create!(fields_)
+    when "UserColumnToRedcapFieldMapping" then record.user_column_to_redcap_field_mapping.create!(fields_)
     else raise ArgumentError.new("No such record type: #{record_type}")
   end
 
@@ -77,16 +78,17 @@ def create_record_of_type(record_type, record_hash)
 
   fields_hash, related_records_hash = fields_and_related_records(record_hash)
   new_record = case record_type
-    when "AdminUser"       then AdminUser.create!(fields_hash)
-    when "ConsentGroup"    then ConsentGroup.create!(fields_hash)
-    when "ConsentQuestion" then ConsentQuestion.create!(fields_hash)
-    when "ConsentStep"     then ConsentStep.create!(fields_hash)
-    when "GlossaryEntry"   then GlossaryEntry.create!(fields_hash)
-    when "ModalFallback"   then ModalFallback.create!(fields_hash)
-    when "QuestionOption"  then QuestionOption.create!(fields_hash)
-    when "StudyCode"       then StudyCode.create!(fields_hash)
-    when "SurveyConfig"    then SurveyConfig.create!(fields_hash)
-    when "User"            then User.create!(fields_hash)
+    when "AdminUser"                      then AdminUser.create!(fields_hash)
+    when "ConsentGroup"                   then ConsentGroup.create!(fields_hash)
+    when "ConsentQuestion"                then ConsentQuestion.create!(fields_hash)
+    when "ConsentStep"                    then ConsentStep.create!(fields_hash)
+    when "GlossaryEntry"                  then GlossaryEntry.create!(fields_hash)
+    when "ModalFallback"                  then ModalFallback.create!(fields_hash)
+    when "QuestionOption"                 then QuestionOption.create!(fields_hash)
+    when "StudyCode"                      then StudyCode.create!(fields_hash)
+    when "SurveyConfig"                   then SurveyConfig.create!(fields_hash)
+    when "User"                           then User.create!(fields_hash)
+    when "UserColumnToRedcapFieldMapping" then UserColumnToRedcapFieldMapping.create!(fields_hash)
     else raise ArgumentError.new("No such record type: #{record_type}")
   end
 
@@ -104,16 +106,17 @@ end
 
 def destroy_all_records_of_type(record_type)
   case record_type
-    when "AdminUser"       then AdminUser.destroy_all
-    when "ConsentGroup"    then ConsentGroup.destroy_all
-    when "ConsentQuestion" then ConsentQuestion.destroy_all
-    when "ConsentStep"     then ConsentStep.destroy_all
-    when "GlossaryEntry"   then GlossaryEntry.destroy_all
-    when "ModalFallback"   then ModalFallback.destroy_all
-    when "QuestionOption"  then QuestionOption.destroy_all
-    when "StudyCode"       then StudyCode.destroy_all
-    when "SurveyConfig"    then SurveyConfig.destroy_all
-    when "User"            then User.destroy_all
+    when "AdminUser"                      then AdminUser.destroy_all
+    when "ConsentGroup"                   then ConsentGroup.destroy_all
+    when "ConsentQuestion"                then ConsentQuestion.destroy_all
+    when "ConsentStep"                    then ConsentStep.destroy_all
+    when "GlossaryEntry"                  then GlossaryEntry.destroy_all
+    when "ModalFallback"                  then ModalFallback.destroy_all
+    when "QuestionOption"                 then QuestionOption.destroy_all
+    when "StudyCode"                      then StudyCode.destroy_all
+    when "SurveyConfig"                   then SurveyConfig.destroy_all
+    when "User"                           then User.destroy_all
+    when "UserColumnToRedcapFieldMapping" then UserColumnToRedcapFieldMapping.destroy_all
     else raise ArgumentError.new("No such record type: #{record_type}")
   end
 end

--- a/db/unseeds.rb
+++ b/db/unseeds.rb
@@ -22,10 +22,12 @@ $permitted_fields = Set[
   'title',
   'tour_videos',
   'value',
-
   'small_note',
   'cancel_btn',
   'review_answers_btn',
+  'user_column',
+  'redcap_field',
+  'redcap_event_name',
 ]
 
 $permitted_record_types = Set[
@@ -39,6 +41,7 @@ $permitted_record_types = Set[
   'StudyCode',
   'SurveyConfig',
   'User',
+  'UserColumnToRedcapFieldMapping',
 ]
 
 def filter_permitted_keys(record)
@@ -79,16 +82,17 @@ end
 
 def fetch_records_of_type(record_type)
   records = case record_type
-    when "AdminUser"       then AdminUser.all
-    when "ConsentGroup"    then ConsentGroup.all
-    when "ConsentQuestion" then ConsentQuestion.all
-    when "ConsentStep"     then ConsentStep.all
-    when "GlossaryEntry"   then GlossaryEntry.all
-    when "ModalFallback"   then ModalFallback.all
-    when "QuestionOption"  then QuestionOption.all
-    when "StudyCode"       then StudyCode.all
-    when "SurveyConfig"    then SurveyConfig.all
-    when "User"            then User.all
+    when "AdminUser"                      then AdminUser.all
+    when "ConsentGroup"                   then ConsentGroup.all
+    when "ConsentQuestion"                then ConsentQuestion.all
+    when "ConsentStep"                    then ConsentStep.all
+    when "GlossaryEntry"                  then GlossaryEntry.all
+    when "ModalFallback"                  then ModalFallback.all
+    when "QuestionOption"                 then QuestionOption.all
+    when "StudyCode"                      then StudyCode.all
+    when "SurveyConfig"                   then SurveyConfig.all
+    when "User"                           then User.all
+    when "UserColumnToRedcapFieldMapping" then UserColumnToRedcapFieldMapping.all
     else raise ArgumentError.new("No such record type: #{record_type}")
   end
 
@@ -102,6 +106,7 @@ end
 def fetch_records
   [
     fetch_records_of_type('StudyCode'),
+    fetch_records_of_type('UserColumnToRedcapFieldMapping'),
     fetch_records_of_type('SurveyConfig'),
     fetch_records_of_type('GlossaryEntry'),
     fetch_records_of_type('ConsentStep'),

--- a/spec/factories/user_column_to_redcap_field_mapping.rb
+++ b/spec/factories/user_column_to_redcap_field_mapping.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :user_column_to_redcap_field_mapping do
+    user_column { "#{user_column}" }
+    redcap_field { "#{redcap_field}" }
+    redcap_event_name { "#{redcap_event_name}" }
+  end
+end

--- a/spec/fixtures/files/empty.yml
+++ b/spec/fixtures/files/empty.yml
@@ -1,5 +1,6 @@
 ---
 - StudyCode: []
+- UserColumnToRedcapFieldMapping: []
 - SurveyConfig: []
 - GlossaryEntry: []
 - ConsentStep: []

--- a/spec/fixtures/files/full.yml
+++ b/spec/fixtures/files/full.yml
@@ -1,6 +1,15 @@
 ---
 - StudyCode:
   - title: A1543457
+- UserColumnToRedcapFieldMapping:
+  - user_column: dob
+    redcap_field: dob
+    redcap_event_name: proband_informatio_arm_1
+  - user_column: state
+    redcap_field: state
+    redcap_event_name: proband_informatio_arm_1
+  - user_column: email
+    redcap_field: email
 - SurveyConfig:
   - name: Radio Button Color
     value: "#02b0db"

--- a/spec/lib/upload_redcap_details_spec.rb
+++ b/spec/lib/upload_redcap_details_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe UploadRedcapDetails do
         content: 'record',
         format: 'json',
         type: 'flat',
-        data: mock_data,
+        data: "\"my data\"",
       }
 
       expect(UploadRedcapDetails.make_redcap_api_payload(mock_data)).to eq(expected_payload)
@@ -124,8 +124,8 @@ RSpec.describe UploadRedcapDetails do
         'my_user_id',
         false
       )
-      expect(actual).to eq({'record_id' => 'my_user_id',
-                            'my_raw_redcap_field' => 'my_answer_string'})
+      expect(actual).to eq([{'record_id' => 'my_user_id',
+                             'my_raw_redcap_field' => 'my_answer_string'}])
     end
 
     it 'produces the correct response for question_type == "multiple checkboxes"' do
@@ -146,11 +146,11 @@ RSpec.describe UploadRedcapDetails do
         false
       )
       expect(actual_do_destroy).to eq(
-        {'record_id' => 'my_user_id',
-        'my_raw_redcap_field___my_raw_redcap_code' => '0'})
+        [{'record_id' => 'my_user_id',
+          'my_raw_redcap_field___my_raw_redcap_code' => '0'}])
       expect(actual_do_not_destroy).to eq(
-        {'record_id' => 'my_user_id',
-        'my_raw_redcap_field___my_raw_redcap_code' => '1'})
+        [{'record_id' => 'my_user_id',
+          'my_raw_redcap_field___my_raw_redcap_code' => '1'}])
     end
 
     it 'produces the correct response for question_type != "multiple checkboxes"' do
@@ -171,11 +171,73 @@ RSpec.describe UploadRedcapDetails do
         false
       )
       expect(actual_do_destroy).to eq(
-        {'record_id' => 'my_user_id',
-        'my_raw_redcap_field' => 'my_raw_redcap_code'})
+        [{'record_id' => 'my_user_id',
+          'my_raw_redcap_field' => 'my_raw_redcap_code'}])
       expect(actual_do_not_destroy).to eq(
-        {'record_id' => 'my_user_id',
-        'my_raw_redcap_field' => 'my_raw_redcap_code'})
+        [{'record_id' => 'my_user_id',
+          'my_raw_redcap_field' => 'my_raw_redcap_code'}])
+    end
+  end
+
+  describe '#user_to_redcap_response' do
+    it 'produces the correct response' do
+      user = create(:user)
+
+      create(
+        :user_column_to_redcap_field_mapping,
+        user_column: 'dob',
+        redcap_field: 'ctrl_dob',
+        redcap_event_name: 'proband_informatio_arm_1'
+      )
+      create(
+        :user_column_to_redcap_field_mapping,
+        user_column: 'flagship',
+        redcap_field: 'ctrl_flagship',
+        redcap_event_name: 'proband_informatio_arm_1'
+      )
+      create(
+        :user_column_to_redcap_field_mapping,
+        user_column: 'email',
+        redcap_field: 'ctrl_email',
+        redcap_event_name: 'proband_informatio_arm_1'
+      )
+      create(
+        :user_column_to_redcap_field_mapping,
+        user_column: 'is_parent',
+        redcap_field: 'ctrl_is_parent',
+        redcap_event_name: 'proband_informatio_arm_1'
+      )
+      create(
+        :user_column_to_redcap_field_mapping,
+        user_column: 'family_name',
+        redcap_field: 'ctrl_family_name',
+        redcap_event_name: ''
+      )
+      create(
+        :user_column_to_redcap_field_mapping,
+        user_column: 'state',
+        redcap_field: 'ctrl_state',
+        redcap_event_name: ''
+      )
+
+      actual = UploadRedcapDetails.user_to_redcap_response(user)
+      expected = [
+        {"record_id"=>user.id,
+         "redcap_event_name"=>"proband_informatio_arm_1",
+         "ctrl_dob"=>user.dob},
+        {"record_id"=>user.id,
+         "redcap_event_name"=>"proband_informatio_arm_1",
+         "ctrl_flagship"=>7},
+        {"record_id"=>user.id,
+         "redcap_event_name"=>"proband_informatio_arm_1",
+         "ctrl_email"=>user.email},
+        {"record_id"=>user.id,
+         "redcap_event_name"=>"proband_informatio_arm_1",
+         "ctrl_is_parent"=>"1"},
+        {"record_id"=>user.id,
+         "ctrl_family_name"=>user.family_name},
+      ]
+      expect(actual).to eq(expected)
     end
   end
 
@@ -184,8 +246,8 @@ RSpec.describe UploadRedcapDetails do
       allow(UploadRedcapDetails).to receive(:question_answer_to_redcap_response).and_return(:data)
       allow(UploadRedcapDetails).to receive(:make_redcap_api_payload).and_return(:payload)
       allow(UploadRedcapDetails).to receive(:call_api)
-      UploadRedcapDetails.perform('id', false)
-      expect(UploadRedcapDetails).to have_received(:make_redcap_api_payload).with("[\"data\"]")
+      UploadRedcapDetails.perform(:question_answer_to_redcap_response, 'id', false)
+      expect(UploadRedcapDetails).to have_received(:make_redcap_api_payload).with(:data)
       expect(UploadRedcapDetails).to have_received(:call_api).with(:payload)
     end
 
@@ -193,7 +255,7 @@ RSpec.describe UploadRedcapDetails do
       allow(UploadRedcapDetails).to receive(:question_answer_to_redcap_response).and_return(nil)
       allow(UploadRedcapDetails).to receive(:make_redcap_api_payload)
       allow(UploadRedcapDetails).to receive(:call_api)
-      UploadRedcapDetails.perform('id', false)
+      UploadRedcapDetails.perform(:question_answer_to_redcap_response, 'id', false)
       expect(UploadRedcapDetails).not_to have_received(:make_redcap_api_payload)
       expect(UploadRedcapDetails).not_to have_received(:call_api)
     end


### PR DESCRIPTION
Closes #77.

The only human-facing change is in Active Admin---A new page to configure which field on the registration page maps to which field in REDCap:

![Screenshot_20221116_153716](https://user-images.githubusercontent.com/11529449/202084885-ee330c4c-2480-4318-ae03-f376192065ed.png)

This page is defined in `app/admin/user_column_to_redcap_field_mapping.rb`. The remainder of the PR sends updates to REDCap whenever a `User` is saved (i.e. created or updated).