### PR TITLE
Only send registration details to REDCap when necessary

### DIFF
--- a/app/lib/upload_redcap_details.rb
+++ b/app/lib/upload_redcap_details.rb
@@ -77,6 +77,10 @@ class UploadRedcapDetails
   def self.user_to_redcap_response(user, *_)
     user_id = user.id
 
+    if UserColumnToRedcapFieldMapping.count == 0
+      return nil
+    end
+
     UserColumnToRedcapFieldMapping.all.map { |user_column_to_redcap_field_mapping|
       user_column, redcap_field, redcap_event_name = [
         user_column_to_redcap_field_mapping.user_column,

--- a/app/lib/upload_redcap_details.rb
+++ b/app/lib/upload_redcap_details.rb
@@ -75,11 +75,11 @@ class UploadRedcapDetails
   end
 
   def self.user_to_redcap_response(user, *_)
-    user_id = user.id
-
     if UserColumnToRedcapFieldMapping.count == 0
       return nil
     end
+
+    user_id = user.id
 
     UserColumnToRedcapFieldMapping.all.map { |user_column_to_redcap_field_mapping|
       user_column, redcap_field, redcap_event_name = [

--- a/spec/lib/upload_redcap_details_spec.rb
+++ b/spec/lib/upload_redcap_details_spec.rb
@@ -180,7 +180,12 @@ RSpec.describe UploadRedcapDetails do
   end
 
   describe '#user_to_redcap_response' do
-    it 'produces the correct response' do
+    it 'produces the correct response for UserColumnToRedcapFieldMapping.count == 0' do
+      user = create(:user)
+      expect(UploadRedcapDetails.user_to_redcap_response(user)).to eq(nil)
+    end
+
+    it 'produces the correct response for UserColumnToRedcapFieldMapping.count > 0' do
       user = create(:user)
 
       create(


### PR DESCRIPTION
Fixes a bug in #79. The issue prevents a user from being able to register when `UserColumnToRedcapFieldMapping` contains no entries and the connection to REDCap is enabled. This is because [`UploadRedcapDetails.call_api` expects API calls to modify exactly one record](https://github.com/Australian-Genomics/CTRL/blob/79b30aca479b11b20f9448b2e97e0291e6831319/app/lib/upload_redcap_details.rb#L17), but the payload produced by CTRL will modify none unless `UserColumnToRedcapFieldMapping.count > 0`.