### PR TITLE
Fix validation on Study ID

### DIFF
--- a/app/lib/user_date_validator.rb
+++ b/app/lib/user_date_validator.rb
@@ -16,7 +16,7 @@ module UserDateValidator
     if codes.all? { |code| Regexp.new(code).match(study_id) }
       true
     else
-      errors.add(:study_id, "Study ID not present in our system. Please try with different one.")
+      errors.add(:study_id, 'Please check Study ID')
       false
     end
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -18,12 +18,7 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable, :timeoutable,
          :recoverable, :rememberable, :trackable, :validatable
 
-  validates :first_name, :family_name, :study_id, presence: true
-
-  validates :study_id, format: {
-    with: /\AA[0-4]{1}[0-9]{1}[2-4]{1}[0-9]{4}\z/,
-    message: 'Please check Study ID'
-  }, allow_blank: true
+  validates :first_name, :family_name, presence: true
 
   validates :flagship,
     :preferred_contact_method,
@@ -46,6 +41,7 @@ class User < ApplicationRecord
 
   validates :terms_and_conditions, acceptance: true
 
+  validates :study_id, presence: true
   validate :check_study_code, if: -> { study_id.present? }
 
   accepts_nested_attributes_for :steps

--- a/features/step_definitions/user_steps.rb
+++ b/features/step_definitions/user_steps.rb
@@ -1,4 +1,10 @@
 def create_visitor
+  @study_id_regexp_str = "\\AA[0-4]{1}[0-9]{1}[2-4]{1}[0-9]{4}\\z"
+  @study_id_regexp = Regexp.new(@study_id_regexp_str)
+
+  @study_id_random_example_1 = @study_id_regexp.random_example
+  @study_id_random_example_2 = @study_id_regexp.random_example
+
   @visitor ||= { first_name: 'Sushant',
                  family_name: 'Ahuja',
                  flagship: 'Acute Care Genomic Testing',
@@ -6,13 +12,12 @@ def create_visitor
                  password: 'please2',
                  password_confirmation: 'please2',
                  dob: '30-05-1995',
-                 study_id: 'A1543457' }
+                 study_id: @study_id_random_example_1 }
 end
 
 def create_study_id
-  title = "\\AA[0-4]{1}[0-9]{1}[2-4]{1}[0-9]{4}\\z"
-  unless StudyCode.find_by(title: title)
-    StudyCode.create!(title: title)
+  unless StudyCode.find_by(title: @study_id_regexp_str)
+    StudyCode.create!(title: @study_id_regexp_str)
   end
 end
 
@@ -61,7 +66,7 @@ def edit_user_details
   fill_in 'user_post_code', with: '3000'
   select 'Phone', from: 'user_preferred_contact_method'
   select 'chILDRANZ', from: 'user_flagship'
-  fill_in 'user_study_id', with: 'A1234567'
+  fill_in 'user_study_id', with: @study_id_random_example_2
   find('#user_is_parent + span').click
   fill_in 'user_child_first_name', with: 'Luca'
   fill_in 'user_child_family_name', with: 'DSouza'
@@ -241,7 +246,7 @@ Then('I should see the new name on the user edit page') do
   expect(page).to have_content('3000')
   expect(page).to have_content('Phone')
   expect(page).to have_content('chILDRANZ')
-  expect(page).to have_content('A1234567')
+  expect(page).to have_content(@study_id_random_example_2)
   expect(page).to have_content('Luca')
 end
 


### PR DESCRIPTION
Fixes a bug introduced in #75 where users couldn't register unless the study code which they entered matched the regex `/\AA[0-4]{1}[0-9]{1}[2-4]{1}[0-9]{4}\z/` _and_ the regex stored in `StudyCode.pluck(:title)`.