### PR TITLE
Fix `features/users/users.feature`

### DIFF
--- a/features/step_definitions/user_steps.rb
+++ b/features/step_definitions/user_steps.rb
@@ -271,7 +271,7 @@ Then('I should not see the new name on the user edit page') do
   expect(page).to_not have_field('user[state]', with: 'VIC')
   expect(page).to_not have_field('user[post_code]', with: '3000')
   expect(page).to_not have_field('user[preferred_contact_method]', with: 'Phone')
-  expect(page).to have_content('Next of Kin')
+  expect(page).to have_content('Next of kin')
 end
 
 Then('I should see the user edit page') do


### PR DESCRIPTION
#110 fixed the labels, as required, but didn't update the tests. (I was a cowboy about merging the PR because I figured we can just Fix It Forward™ if it breaks the build.)