### PR TITLE
Allow email validation to use REDCap event names

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -119,7 +119,7 @@ class User < ApplicationRecord
 
   def upload_redcap_details
     Redcap.perform(
-      :user_to_redcap_response,
+      :user_to_import_redcap_response,
       :get_import_payload,
       record: self,
       expected_count: 1)
@@ -127,8 +127,8 @@ class User < ApplicationRecord
 
   def download_redcap_details
     Redcap.perform(
-      :identity_data_fetcher,
+      :user_to_export_redcap_response,
       :get_export_payload,
-      record: study_id)
+      record: self)
   end
 end


### PR DESCRIPTION
The payload produced by the `Redcap::get_export_payload` function should, according to REDCap's documentation, return a list of records. You can ask REDCap for a particular record by providing a `study_id`. You might expect this to result in a list containing either 1 or 0 entries, if the record is found or not, respectively. But, in fact, you're able to get more than one "record". This is because REDCap record API appears not to be returning records, but the _history_ of _instruments and events_ for the particular record you specify. So if a record has multiple instruments, you'll get multiple "records", and it's a repeating event which was saved many times, you'll also get multiple "records"---All with the same `record_id`.

Thankfully, REDCap lets you filter by event, which is what's implemented in this PR. We use the `user_column: 'email'` row in the `UserColumnToRedcapFieldMapping` table to filter REDCap's "records".

To avoid receiving a record's history, we simply disable repeating events in REDCap (which was done just by clicking through REDCap's UI). It would be nice to have support for repeating events in the future, but that appears not to be needed for now.