### PR TITLE
Open terms and conditions in new tab

### DIFF
--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -144,7 +144,8 @@
                   'user_registration.i_agree_to_the',
                   terms_and_conditions_link: link_to(
                     t('user_registration.terms_and_conditions'),
-                    'https://www.australiangenomics.org.au/terms-and-conditions/ctrl-platform-terms-and-conditions/'
+                    'https://www.australiangenomics.org.au/terms-and-conditions/ctrl-platform-terms-and-conditions/',
+                    target: '_blank'
                   )
                 ).html_safe
               %>


### PR DESCRIPTION
The 'Terms and Conditions' link on the registration page should open in a new tab:

![screenshot_2023-01-30_at_2 01 22_pm](https://user-images.githubusercontent.com/11529449/215385299-601e3d20-f489-49b0-9132-e2e1ce620b05.png)

@rosiejbrown was the original reporter of this issue