### PR TITLE
Fix bug preventing download of `QuestionAnswer` CSVs from Active Admin

### DIFF
--- a/app/admin/question_answers.rb
+++ b/app/admin/question_answers.rb
@@ -43,14 +43,14 @@ ActiveAdmin.register QuestionAnswer do
     column :answer
     column(:answer_redcap_field) do |question_answer|
       redcap_response = Redcap.question_answer_to_redcap_response(
-        question_answer, false
+        record: question_answer
       ) || [{}]
 
       redcap_response.first.except('record_id').keys.first
     end
     column(:answer_redcap_code) do |question_answer|
       redcap_response = Redcap.question_answer_to_redcap_response(
-        question_answer, false
+        record: question_answer
       ) || [{}]
 
       redcap_response.first.except('record_id').values.first


### PR DESCRIPTION
Fixes this:

![Screenshot_20230216_103720](https://user-images.githubusercontent.com/11529449/219218127-16d01762-511a-4d47-8c49-42610e0aa7de.png)
