### PR TITLE
Fix Dockerfile entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM debian:bullseye-20230502
 
 SHELL ["/bin/bash", "-lc"]
-ENTRYPOINT ["/bin/bash", "-lc"]
+ENTRYPOINT ["/bin/bash", "-lc", "exec \"$@\"", "--"]
 
 # Use a directory called /code in which to store
 # this application's files. (The directory name


### PR DESCRIPTION
The build passed for https://github.com/Australian-Genomics/CTRL/pull/146 because the tests didn't run. I'd set the Docker entrypoint such that everything after the first argument was ignored. So, for example, instead of the build running `docker-compose --env-file=.env.test run web bundle exec rspec`, it ran `docker-compose --env-file=.env.test run web bundle`.